### PR TITLE
Quick fix for failing SQL

### DIFF
--- a/header.php
+++ b/header.php
@@ -27,6 +27,9 @@ require_once __DIR__ . '/include/functions.php';
 
 require_once __DIR__ . '/include/common.php';
 
+/* temporary fix for some ugly queries on MySQL 5.7+ */
+\XoopsDatabaseFactory::getDatabaseConnection()->queryf("SET SESSION sql_mode = 'TRADITIONAL';");
+
 /** @var Tag\Helper $helper */
 $helper = Tag\Helper::getInstance();
 


### PR DESCRIPTION
A query in tag module fails with error 1055. Discussion here:
https://xoops.org/modules/newbb/viewtopic.php?post_id=364611

This changes the SQL_MODE for the session to allow the offending ONLY_FULL_GROUP_BY violation.

I needed the tag module to work for theme testing, and this was the quickest fix I could find. The issue deserves a complete fix, that may include changes to core and module code.

If more proper changes exist, please ignore this.
